### PR TITLE
Fix: Half-precision GPU CrossProduct allocation error

### DIFF
--- a/src/adapters/RLinearAlgebra.cpp
+++ b/src/adapters/RLinearAlgebra.cpp
@@ -9,6 +9,7 @@
 #include <adapters/RLinearAlgebra.hpp>
 #include <adapters/RHelpers.hpp>
 #include <kernels/Promoter.hpp>
+#include <kernels/ContextManager.hpp>
 #include <utilities/MPCRDispatcher.hpp>
 
 
@@ -133,7 +134,11 @@ RCrossProduct(DataType *aInputA, SEXP aInputB) {
 
     auto precision = aInputA->GetPrecision();
 
-    auto pOutput = new DataType(precision);
+    // Get current operation placement to allocate output correctly
+    auto context = ContextManager::GetOperationContext();
+    auto operation_placement = context->GetOperationPlacement();
+
+    auto pOutput = new DataType(precision, operation_placement);
     SIMPLE_DISPATCH_WITH_HALF(precision, linear::CrossProduct, *aInputA,
                               *temp_b, *pOutput, transpose, false)
 
@@ -179,7 +184,11 @@ RTCrossProduct(DataType *aInputA, SEXP aInputB) {
 
     auto precision = aInputA->GetPrecision();
 
-    auto pOutput = new DataType(precision);
+    // Get current operation placement to allocate output correctly
+    auto context = ContextManager::GetOperationContext();
+    auto operation_placement = context->GetOperationPlacement();
+
+    auto pOutput = new DataType(precision, operation_placement);
     SIMPLE_DISPATCH_WITH_HALF(precision, linear::CrossProduct, *aInputA, *temp_b,
                     *pOutput,
                     false, true)


### PR DESCRIPTION
### **Problem:**
Half-precision matrix multiplication on GPU was failing with the error:
_Error: Cannot perform half gemm using CPU_


This occurred when using `%*%` or `crossprod()` with half-precision MPCR objects allocated on GPU, even though `MPCR.SetOperationPlacement("GPU")` was correctly set.

### Root Cause:
In `src/adapters/RLinearAlgebra.cpp`, the `RCrossProduct` and `RTCrossProduct` functions were creating output `DataType` objects using a constructor with a **default CPU placement parameter**, ignoring the current operation context set by the user.
